### PR TITLE
Fixing tab behavior for autocomplete

### DIFF
--- a/pyqtconsole/autocomplete.py
+++ b/pyqtconsole/autocomplete.py
@@ -45,7 +45,7 @@ class AutoComplete(QObject):
             return False
 
         if self.mode == COMPLETE_MODE.DROPDOWN:
-            if self.parent().input_buffer().strip():
+            if self.parent().input_buffer().split("\n")[-1].strip():
                 if self.completing():
                     self.complete()
                 else:


### PR DESCRIPTION
Autocomplete's tab handling was preventing indentation inside statements.

Addesses #74